### PR TITLE
修改帮助菜单的关键词判断方式为相等则执行

### DIFF
--- a/Recv_Msg_Dispose/Room_Msg_Dispose.py
+++ b/Recv_Msg_Dispose/Room_Msg_Dispose.py
@@ -249,7 +249,7 @@ class Room_Msg_Dispose:
                 msg.content.strip())
             self.wcf.send_text(msg=dream_msg, receiver=msg.roomid, aters=msg.sender)
         # help帮助菜单
-        elif self.judge_keyword(keyword=self.HelpMenu_Words, msg=msg.content.strip(), list_bool=True, split_bool=True):
+        elif self.judge_keyword(keyword=self.HelpMenu_Words, msg=msg.content.strip(), list_bool=True, equal_bool=True, split_bool=True):
             Thread(target=self.get_help, name="Help帮助菜单", args=(msg,)).start()
         # 自定义回复
         Thread(target=self.custom_get, name="自定义回复", args=(msg,)).start()


### PR DESCRIPTION
修改帮助菜单的关键词判断方式为相等则执行

原来的代码中帮助菜单功能中judge_keyword函数默认只有list_bool为True，导致关键词判断的时候无法进入“需要相等则执行”，将默认值equal_bool参数设置为True后符合“需要相等则执行”条件则可以正常执行：

如下代码所示，需要同时满足list_bool和equal_bool为True才可进入帮助菜单，否则只会有help命令生效，帮助、菜单、帮助菜单均不生效。

        # 如果触发词是列表 并且需要相等则执行
        if list_bool and equal_bool:
            for word in keyword:
                if word == msg:
                    return True